### PR TITLE
Fix getting min, max in building cutoffs

### DIFF
--- a/crm_rfm_modeling/rfm_utils.py
+++ b/crm_rfm_modeling/rfm_utils.py
@@ -60,8 +60,8 @@ def build_cutoffs(dataset, variable, func):
                 divider = func(dataset_copy[variable])
                 calc_list.append(divider)
                 dataset_copy = dataset_copy[dataset_copy[variable] >= divider]
-            mn = dataset_copy[variable].min()
-            mx = dataset_copy[variable].max()
+            mn = dataset[variable].min()
+            mx = dataset[variable].max()
             cutoffs = [(mn, calc_list[0]),
                        (calc_list[0], calc_list[1]),
                        (calc_list[1], calc_list[2]),
@@ -73,8 +73,8 @@ def build_cutoffs(dataset, variable, func):
                 divider = func(dataset_copy[variable])
                 calc_list.append(divider)
                 dataset_copy = dataset_copy[dataset_copy[variable] <= divider]
-            mn = dataset_copy[variable].min()
-            mx = dataset_copy[variable].max()
+            mn = dataset[variable].min()
+            mx = dataset[variable].max()
             cutoffs = [(mx, calc_list[3]),
                        (calc_list[3], calc_list[2]),
                        (calc_list[2], calc_list[1]),


### PR DESCRIPTION
crm-rfm-modeling/rfm_utils.py - Line 63, 64 / Line 76, 77

Instead of variable 'dataset_copy', There should be variable 'dataset'. because it determines the min and max of whole dataset. The variable 'mn'(min) and 'mx' (max) is calculated by using the the variable 'dataset_copy' which is generated lastly inside of the loop. There's many NaNs in fitted data without changing variable 'dataset_copy' to 'dataset'. Thank you. 