### PR TITLE
Updating recency_end_date reference

### DIFF
--- a/crm_rfm_modeling/rfm.py
+++ b/crm_rfm_modeling/rfm.py
@@ -107,7 +107,7 @@ class RFM:
                 raise ValueError('Error: expected 3 columns for dataset type of '+ self.dataset_type +'; received: ' + str(data.shape[1]))
 
         if self.dataset_type == 'transactional':
-            self.data = convert_transaction_to_user(self.data, recency_end_date=recency_end_date)
+            self.data = convert_transaction_to_user(self.data, recency_end_date=self.recency_end_date)
 
         #### Scoring Section
         #Retrieving the indexes for each R-F-M categorized within each dictionary for each score


### PR DESCRIPTION
The recency_end_date variable is referencing the user passed variable value and not the class attribute that is transformed using the strptime() function:
self.data = convert_transaction_to_user(self.data, recency_end_date=recency_end_date)


The variable should be prefixed with the self. keyword:
self.data = convert_transaction_to_user(self.data, recency_end_date=self.recency_end_date)

This is causing an issue when the recency_end_date value is passed to the convert_transaction_to_user() function, specifically on this line of code:

df_recency = df.groupby([id_col])[date_col].max().apply(lambda date: (end_date - date).days).astype(float)
TypeError: unsupported operand type(s) for -: 'str' and 'Timestamp'